### PR TITLE
Base64 encodes (url variant) file hash - 22 bytes instead of 32

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,8 +25,9 @@ var (
 	parallelFlag   = flags.Int("parallel", 10, "Number of parallel uploads (default=10)")
 	hashPrefixFlag = flags.Bool("auto-content-hash-prefix", false,
 		"Compute the md5 hash of a file's contents and set it as a first path segment")
-	syncFlag = flags.Bool("sync", false, "Only upload files that are new or have changed")
-	listFlag = flags.Bool("list", false, "List files data to be processed")
+	hashPrefixBytesFlag = flags.Uint("prefix_bytes", 6, "Number of bytes of md5 hash to use in filename hash. Max 16. 6 and 12 best (base64 encoding)")
+	syncFlag            = flags.Bool("sync", false, "Only upload files that are new or have changed")
+	listFlag            = flags.Bool("list", false, "List files data to be processed")
 )
 
 const VERSION = "0.2.0"

--- a/s3.go
+++ b/s3.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/md5"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -147,7 +148,7 @@ func (s *S3Upload) sourceFiles() ([]*FileData, error) {
 		if _, err := io.Copy(h, file); err != nil {
 			return err
 		}
-		md5Hash := fmt.Sprintf("%x", h.Sum(nil))
+		md5Hash := base64.URLEncoding.EncodeToString(h.Sum(nil))
 
 		// add md5 hash as prefix if required
 		hashPrefix := ""


### PR DESCRIPTION
128-bit md5 checksum is 32 chars long as hex (4 bytes per char), but only 22 chars long as base64 (6 bytes per char)