### PR TITLE
manifest flag added, always compare md5 when sync

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,21 +12,28 @@ import (
 var (
 	flags = flag.NewFlagSet("s3up", flag.ExitOnError)
 
-	versionFlag         = flags.Bool("version", false, "print the version and exit")
-	configFlag          = flags.String("config", "", "config file")
-	accessKeyFlag       = flags.String("access-key", "", "s3 access key")
-	secretKeyFlag       = flags.String("secret-key", "", "s3 secret key")
-	regionFlag          = flags.String("region", "", "s3 region")
-	bucketFlag          = flags.String("bucket", "", "s3 bucket")
-	prefixFlag          = flags.String("prefix", "", "s3 path prefix")
-	sourcePathFlag      = flags.String("source", "", "local source path to upload")
-	dryrunFlag          = flags.Bool("dryrun", false, "Dryrun, dont upload anything, just list files to upload")
-	confirmFlag         = flags.Bool("confirm", false, "Confirm final settings with user before triggering upload")
-	parallelFlag        = flags.Int("parallel", 10, "Number of parallel uploads (default=10)")
-	hashPrefixFlag      = flags.Bool("auto-content-hash-prefix", false, "Compute the md5 hash of a file's contents and set it as a first path segment")
-	hashPrefixBytesFlag = flags.Uint("content-hash-bytes", 6, "Number of bytes of md5 hash to use in filename hash. Max 16. 6 and 12 best (base64 encoding)")
-	syncFlag            = flags.Bool("sync", false, "Only upload files that are new or have changed")
-	listFlag            = flags.Bool("list", false, "List files data to be processed")
+	versionFlag    = flags.Bool("version", false, "print the version and exit")
+	configFlag     = flags.String("config", "", "config file")
+	accessKeyFlag  = flags.String("access-key", "", "s3 access key")
+	secretKeyFlag  = flags.String("secret-key", "", "s3 secret key")
+	regionFlag     = flags.String("region", "", "s3 region")
+	bucketFlag     = flags.String("bucket", "", "s3 bucket")
+	prefixFlag     = flags.String("prefix", "", "s3 path prefix")
+	sourcePathFlag = flags.String("source", "", "local source path to upload")
+	dryrunFlag     = flags.Bool("dryrun", false,
+		"Dryrun, dont upload anything, just list files to upload")
+	confirmFlag = flags.Bool("confirm", false,
+		"Confirm final settings with user before triggering upload")
+	parallelFlag   = flags.Int("parallel", 10, "Number of parallel uploads (default=10)")
+	hashPrefixFlag = flags.Bool("auto-content-hash-prefix", true,
+		"Compute the md5 hash of a file's contents and us it for first path segment")
+	hashPrefixBytesFlag = flags.Uint("content-hash-bytes", 6,
+		"Number of bytes of md5 hash to use in filename hash. Max 16. 6 and 12 best (base64 encoding)")
+	syncFlag = flags.Bool("sync", false,
+		"Only upload files that are new or have changed")
+	listFlag = flags.Bool("list", false,
+		"List files data to be processed (outputs in JSON format)")
+	manifestFlag = flags.String("manifest", "", "path to write a manifest file")
 )
 
 const VERSION = "0.3.0"


### PR DESCRIPTION
this PR includes changes for https://github.com/goware/s3up/issues/5

also a couple of adjustments:
- brining back `auto-content-hash-prefix` flag to be configurable (it was forced to tru by `content-hash-bytes`), default value `true`
- don't do `file.Stat()` twice
